### PR TITLE
add doc for modifying toolkit version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Get the sandbox, aztec-cli and other tooling with this command:
 bash -i <(curl -s install.aztec.network)
 ```
 
+Modify the toolkit version to match the version (`x.x.x`) specified in Nargo.toml with:
+
+```
+aztec-up x.x.x
+```
+
 Start the sandbox with:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Modify the toolkit version to match the version (`x.x.x`) specified in Nargo.tom
 aztec-up x.x.x
 ```
 
+or update to the latest version with:
+
+```bash
+aztec-up
+```
+
 Start the sandbox with:
 
 ```bash


### PR DESCRIPTION
Given the rapid evolution of Aztec toolkits, it is advisable to provide documentation detailing the process for modifying the toolkit version to ensure compatibility with the version specified in the contract. This will facilitate the onboarding process for developers.