### PR TITLE
0.65. failing

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [ "" ]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.65.1", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.65.2", directory = "noir-projects/aztec-nr/aztec" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [ "" ]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.65.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.65.1", directory = "noir-projects/aztec-nr/aztec" }

--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [ "" ]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.63.1", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.65.0", directory = "noir-projects/aztec-nr/aztec" }

--- a/codegenCache.json
+++ b/codegenCache.json
@@ -1,3 +1,6 @@
 {
-  "easy_private_voting_contract-EasyPrivateVoting.json": "4662c1c3f60516d75a615dd7f04c52b2c8536e641e8ad3d3f25a052a48d7ed40"
+  "easy_private_voting_contract-EasyPrivateVoting.json": {
+    "contractName": "EasyPrivateVoting",
+    "hash": "84c84894f5469156e603daa4979a81b46bf5963c0627c799fff51300b64db164"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "update": "aztec update --contract . && ./.github/scripts/update_contract.sh $(grep -oP 'tag\\s*=\\s*\"\\K[^\"]+' \"Nargo.toml\" | head -1) && yarn"
   },
   "dependencies": {
-    "@aztec/accounts": "0.63.1",
-    "@aztec/aztec.js": "0.63.1",
-    "@aztec/noir-contracts.js": "0.63.1",
+    "@aztec/accounts": "0.65.0",
+    "@aztec/aztec.js": "0.65.0",
+    "@aztec/noir-contracts.js": "0.65.0",
     "@types/node": "^22.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "update": "aztec update --contract . && ./.github/scripts/update_contract.sh $(grep -oP 'tag\\s*=\\s*\"\\K[^\"]+' \"Nargo.toml\" | head -1) && yarn"
   },
   "dependencies": {
-    "@aztec/accounts": "0.65.0",
-    "@aztec/aztec.js": "0.65.0",
-    "@aztec/noir-contracts.js": "0.65.0",
+    "@aztec/accounts": "0.65.1",
+    "@aztec/aztec.js": "0.65.1",
+    "@aztec/noir-contracts.js": "0.65.1",
     "@types/node": "^22.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "update": "aztec update --contract . && ./.github/scripts/update_contract.sh $(grep -oP 'tag\\s*=\\s*\"\\K[^\"]+' \"Nargo.toml\" | head -1) && yarn"
   },
   "dependencies": {
-    "@aztec/accounts": "0.65.1",
-    "@aztec/aztec.js": "0.65.1",
-    "@aztec/noir-contracts.js": "0.65.1",
+    "@aztec/accounts": "0.65.2",
+    "@aztec/aztec.js": "0.65.2",
+    "@aztec/noir-contracts.js": "0.65.2",
     "@types/node": "^22.5.1"
   },
   "devDependencies": {

--- a/src/main.nr
+++ b/src/main.nr
@@ -7,13 +7,13 @@ contract EasyPrivateVoting {
         keys::getters::get_public_keys,
         macros::{functions::{initializer, internal, private, public}, storage::storage},
     };
-    use dep::aztec::prelude::{AztecAddress, Map, PublicMutable, SharedImmutable};
+    use dep::aztec::prelude::{AztecAddress, Map, PublicImmutable, PublicMutable};
     #[storage]
     struct Storage<Context> {
         admin: PublicMutable<AztecAddress, Context>, // admin can end vote
         tally: Map<Field, PublicMutable<Field, Context>, Context>, // we will store candidate as key and number of votes as value
         vote_ended: PublicMutable<bool, Context>, // vote_ended is boolean
-        active_at_block: SharedImmutable<u32, Context>, // when people can start voting
+        active_at_block: PublicImmutable<u32, Context>, // when people can start voting
     }
 
     #[public]

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -76,12 +76,12 @@ describe("Voting", () => {
         const contract = await EasyPrivateVotingContract.deploy(wallets[0], accounts[0].address).send().deployed();
         await contract.methods.cast_vote(candidate).send().wait();
 
-        const secondVoteReceipt = await contract.methods.cast_vote(candidate).send().getReceipt();
-        expect(secondVoteReceipt).toEqual(
-            expect.objectContaining({
-                status: TxStatus.DROPPED,
-            }),
-        );
+        await expect(contract.methods.cast_vote(candidate).send().wait()).rejects.toThrow(/Nullifier collision/);
+        // if we skip simulation, tx is dropped
+        await expect(
+            contract.methods.cast_vote(candidate).send({ skipPublicSimulation: true }).wait(),
+        ).rejects.toThrow('Reason: Tx dropped by P2P node.');
+
     }, 300_000)
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,40 +15,40 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aztec/accounts@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.65.1.tgz#423b6f7fa1eef2fdabba5e725682dc00e2330e44"
-  integrity sha512-uLhj6gAwwJobrJpm6nDEKAjKhf+xCaUqTh9jwDT/G+9S8kGUDtoknJVzkj+to6tMqjqAltG2mUsgrsQzgJHPBg==
+"@aztec/accounts@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.65.2.tgz#302e1a7d3db8c875e8e4e2c00e61b0ac50b94d68"
+  integrity sha512-0Xe1H+CP2DLGE+0yhSjree0SvydH+n3YsgRuDqQR2657su/39wCMq1HNTpc+pRu3a38clecDjyvVUo/dH3YKXQ==
   dependencies:
-    "@aztec/aztec.js" "0.65.1"
-    "@aztec/circuit-types" "0.65.1"
-    "@aztec/circuits.js" "0.65.1"
-    "@aztec/entrypoints" "0.65.1"
-    "@aztec/ethereum" "0.65.1"
-    "@aztec/foundation" "0.65.1"
-    "@aztec/types" "0.65.1"
+    "@aztec/aztec.js" "0.65.2"
+    "@aztec/circuit-types" "0.65.2"
+    "@aztec/circuits.js" "0.65.2"
+    "@aztec/entrypoints" "0.65.2"
+    "@aztec/ethereum" "0.65.2"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/types" "0.65.2"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.65.1.tgz#205f3ae3cd23eaf0135d3162f82f51ed2c329d05"
-  integrity sha512-5hrSv2g4mkvOAf4h+R8FpzEcGFHZFpytWLw9dzyZfOS+rhOGxVTe92m8O3lp5SrqdWAU7KSYNMB/xtyjMCjObw==
+"@aztec/aztec.js@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.65.2.tgz#3e0305c98c0f89c3c13c6408327730460e61917e"
+  integrity sha512-+jUEMzIfPEhTVHgyuPzM4IQ5mqMxJm4qgaDb6zkTt5DwGrAA6H8xltUy+8jDJW0LOGNEizmkODODJ4OTr6480w==
   dependencies:
-    "@aztec/circuit-types" "0.65.1"
-    "@aztec/circuits.js" "0.65.1"
-    "@aztec/ethereum" "0.65.1"
-    "@aztec/foundation" "0.65.1"
-    "@aztec/l1-artifacts" "0.65.1"
-    "@aztec/protocol-contracts" "0.65.1"
-    "@aztec/types" "0.65.1"
+    "@aztec/circuit-types" "0.65.2"
+    "@aztec/circuits.js" "0.65.2"
+    "@aztec/ethereum" "0.65.2"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/l1-artifacts" "0.65.2"
+    "@aztec/protocol-contracts" "0.65.2"
+    "@aztec/types" "0.65.2"
     axios "^1.7.2"
     tslib "^2.4.0"
     viem "^2.7.15"
 
-"@aztec/bb.js@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.65.1.tgz#a483601d4e621ee350cfcd57185d2ceee03869f3"
-  integrity sha512-MxHDapvIoOK67/B7IRXMlWNV3Gcih+bmlg+SPCRe8JuO0cXRK2x6dqzTxgbd75u3kNTkyrcBhgXrvNuL9N/C/w==
+"@aztec/bb.js@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.65.2.tgz#93acdd9111c95095eece7999d88b03aced344446"
+  integrity sha512-4wOZgB+6nkhJTocOTDlOlO2vs9tpL654EF3sUeNfmWHT+Titvf1ylLIezgO7BYkgMFMGPfKjKpMGujDpyrwAjw==
   dependencies:
     comlink "^4.4.1"
     commander "^10.0.1"
@@ -57,15 +57,15 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/circuit-types@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.65.1.tgz#abdfc8e180de89145d8fe768d8d6342adc50bc7e"
-  integrity sha512-xNOIvXn5Hu8YCejCfeN8Jx+tAnrohiAhi9jvLDkIRpS3OuCIR3a6Ot+xJQbxOGGXwDyfaDmw7o33rpc3qS5MYA==
+"@aztec/circuit-types@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.65.2.tgz#07585d322d6e23ec41d3d6621ab4501cb18d7c3d"
+  integrity sha512-nHG64hYxdQSOOAEGIpuUwmXeXvzn89rA9RlI6ITWY7aEZWqle6ML2SpRUcS05fkgL/yrzVdtyZlb6CWqaMUbag==
   dependencies:
-    "@aztec/circuits.js" "0.65.1"
-    "@aztec/ethereum" "0.65.1"
-    "@aztec/foundation" "0.65.1"
-    "@aztec/types" "0.65.1"
+    "@aztec/circuits.js" "0.65.2"
+    "@aztec/ethereum" "0.65.2"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/types" "0.65.2"
     browserify-cipher "^1.0.1"
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
@@ -73,39 +73,39 @@
     tslib "^2.5.0"
     zod "^3.23.8"
 
-"@aztec/circuits.js@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.65.1.tgz#072ca55ba7fff075a737de7562dba35a656a5b85"
-  integrity sha512-zxxtkLf4Y4lDCgM/k4ZNWLIlUY/KEDwVKqClkfLYTjlrpO6sMPbQPQGRgrpJZetPi6YLXwUWkm73BhKo6VvXHA==
+"@aztec/circuits.js@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.65.2.tgz#6650740cc9262c49b40dc584ddb0819428cb9276"
+  integrity sha512-UhzeBkZjZTuFsgxjffR8qvdNMXO0ju0zkRX1l6SZJCga/N61Cal72bEaOpZu0P0tg+yATVNqbJeA482ZGCqutA==
   dependencies:
-    "@aztec/bb.js" "0.65.1"
-    "@aztec/ethereum" "0.65.1"
-    "@aztec/foundation" "0.65.1"
-    "@aztec/types" "0.65.1"
+    "@aztec/bb.js" "0.65.2"
+    "@aztec/ethereum" "0.65.2"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/types" "0.65.2"
     eslint "^8.35.0"
     lodash.chunk "^4.2.0"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/entrypoints@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.65.1.tgz#46cd2bc5a24fc5c38ee99da922b6293bb16a6315"
-  integrity sha512-qpobFS7I+M4txKOOgByveHZF6RZujPXZ7J5RWAR76zzCfKGrEG2TbH1St1G3nvSFVIbx4CzWlHzcyW28yeGmnA==
+"@aztec/entrypoints@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.65.2.tgz#86c8c9ad127f2b77a77a132145869d1707493418"
+  integrity sha512-LjtEc6vyN0Gd741G/gIP6N+6c2xEeetiNYPxSpYZgH3d8j741LiZJWesEvQXX1QVTaj1QukiANgTAlPOr9N3pw==
   dependencies:
-    "@aztec/aztec.js" "0.65.1"
-    "@aztec/circuit-types" "0.65.1"
-    "@aztec/circuits.js" "0.65.1"
-    "@aztec/foundation" "0.65.1"
-    "@aztec/protocol-contracts" "0.65.1"
+    "@aztec/aztec.js" "0.65.2"
+    "@aztec/circuit-types" "0.65.2"
+    "@aztec/circuits.js" "0.65.2"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/protocol-contracts" "0.65.2"
     tslib "^2.4.0"
 
-"@aztec/ethereum@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.65.1.tgz#1d33b02621ca9756c8b363be477abe31c9355a78"
-  integrity sha512-3arKI8uLJd8uzaLZfcHb0AR28ikAPKSs37wqxrEWnjr9FwBe2XmbgzVjNWbTanyRCJh1dRpzdywGSrxtFZhvyw==
+"@aztec/ethereum@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.65.2.tgz#2bf1eae2dd69a8305dd3326e4007505cd259ce7b"
+  integrity sha512-9CXVLnVqSTSJqchKbhrX/3939PIhzQZY0m7kIqVVIM+vOJ4EnH/YOnyCO+jnAaODQdNbrEtJSrk/Y0l0dKfQnA==
   dependencies:
-    "@aztec/foundation" "0.65.1"
-    "@aztec/l1-artifacts" "0.65.1"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/l1-artifacts" "0.65.2"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     get-port "^7.1.0"
@@ -113,12 +113,12 @@
     viem "^2.7.15"
     zod "^3.23.8"
 
-"@aztec/foundation@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.65.1.tgz#1f401ff5556e7de7995e20c326ee3410fabb6048"
-  integrity sha512-4HYzzw2NpFcSxuEX0alhVyMDGsUJkIFaJBHTy+7gvOR52z4alTKDC1UIpFFCuKzpDiq+iSqmc/m41YO6hBXUGQ==
+"@aztec/foundation@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.65.2.tgz#08f72d77daec1848f0159cbe45ca31c74bff3465"
+  integrity sha512-oRwumLD1W6O5XpIfSGrFNthahME3TAJwO9McbZpm0w6TjHwW4wFtdc1M3eF3a1HVrNigRGhqVFbRtVeqfwIIGA==
   dependencies:
-    "@aztec/bb.js" "0.65.1"
+    "@aztec/bb.js" "0.65.2"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "^1.2.0"
     bn.js "^5.2.1"
@@ -139,39 +139,39 @@
     sha3 "^2.1.4"
     zod "^3.23.8"
 
-"@aztec/l1-artifacts@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.65.1.tgz#1d7d4cf4b2552e4c0f40405f6753ab3d044b0a3a"
-  integrity sha512-7gjgzB+6FUdTZjUz1372a/Lw/o97L9gC65xaRn7apUjoS2NEJwx8qAnJUzP+2wlZ3bJ7m4CxQoTvIwTfGSx/nA==
+"@aztec/l1-artifacts@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.65.2.tgz#723aff93e0785ffdeb1fddc111f8ef4197d0bf42"
+  integrity sha512-gwNcWyqyjcbQhfzKk27jAB6I32U4MRlGp5MsORANf8TX4IKiZujOZJyJM1xZT1d0zA37prfBQxZbOv+IStRAjA==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/noir-contracts.js@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.65.1.tgz#74f5f89c9c1fa34b54db927d1026890495e6a4f6"
-  integrity sha512-Mi11v03Az9mQXPJzlNCruPzu+gRSnnQVY4m7pnNvVEl4UQTVQi3q6yhN9pDm64zYXxuPlmdnW49s66Mmh7G68g==
+"@aztec/noir-contracts.js@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.65.2.tgz#07af4a60683e1812abb52a3cc872fb544c12f6cb"
+  integrity sha512-l2fCgbSvRIZh16BM2dnhsWZqj52Z715wNVp8BvtKMV8vdZax7OpjFEopw6pzaBehPl6xele5QmEpGXZfRlW6cw==
   dependencies:
-    "@aztec/aztec.js" "0.65.1"
+    "@aztec/aztec.js" "0.65.2"
     tslib "^2.4.0"
 
-"@aztec/protocol-contracts@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.65.1.tgz#cc897c05197efab6220f86f053bd86ec51d487da"
-  integrity sha512-84cdnPxqEYhAgaibBzkD9eysU7oeuwvskRga2RYLDiU71sdYRuOipvOJun+pVle//Q7ceGS1I4hiAdkzeGk+wg==
+"@aztec/protocol-contracts@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.65.2.tgz#d30627718fcd9a23aca8a755a3afd5a48beb39f4"
+  integrity sha512-U6l5Vq3Nx8J/GpCNtNdu+iFJvIP5+Z8YdofErD+IjemirJiJESzEf17EC1mBe4SY++j5E9MKDj8PRoYh0sXR1g==
   dependencies:
-    "@aztec/circuits.js" "0.65.1"
-    "@aztec/foundation" "0.65.1"
-    "@aztec/types" "0.65.1"
+    "@aztec/circuits.js" "0.65.2"
+    "@aztec/foundation" "0.65.2"
+    "@aztec/types" "0.65.2"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/types@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.65.1.tgz#219cf2196c922bf20d0fdaedd053143b2c331de1"
-  integrity sha512-pcRd+hamxPS1QpeFdvN0GT7eJttZ4ufvUaKj3k/95DrMcCPIhnFt/EOd4oS9peVRfPS6dfkVKE0EuO2rg226Vg==
+"@aztec/types@0.65.2":
+  version "0.65.2"
+  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.65.2.tgz#84d1cbdd80a8fd94421366d50acc606ab43a9160"
+  integrity sha512-elhRENsUy96x2+Lc52VUMvE9CR86Qoes9/V+vJcam4D1YrorlKi/XdjQs7ysV2Mja4tdz7JOy6FlymcdXBrwLQ==
   dependencies:
-    "@aztec/ethereum" "0.65.1"
-    "@aztec/foundation" "0.65.1"
+    "@aztec/ethereum" "0.65.2"
+    "@aztec/foundation" "0.65.2"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7":
   version "7.24.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,56 +15,57 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aztec/accounts@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.65.0.tgz#50a37ddb386d7a9dc2bd40260b5c3abb535ffcb8"
-  integrity sha512-bmCSoe6TtHVbRhhSeDdVaTEzpJ8ZR1C1ZhdtHATLX5sbfkod/whNYnTwbXfnu76cIXAROiAX6tqKYrsTDIAIuA==
+"@aztec/accounts@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.65.1.tgz#423b6f7fa1eef2fdabba5e725682dc00e2330e44"
+  integrity sha512-uLhj6gAwwJobrJpm6nDEKAjKhf+xCaUqTh9jwDT/G+9S8kGUDtoknJVzkj+to6tMqjqAltG2mUsgrsQzgJHPBg==
   dependencies:
-    "@aztec/aztec.js" "0.65.0"
-    "@aztec/circuit-types" "0.65.0"
-    "@aztec/circuits.js" "0.65.0"
-    "@aztec/entrypoints" "0.65.0"
-    "@aztec/ethereum" "0.65.0"
-    "@aztec/foundation" "0.65.0"
-    "@aztec/types" "0.65.0"
+    "@aztec/aztec.js" "0.65.1"
+    "@aztec/circuit-types" "0.65.1"
+    "@aztec/circuits.js" "0.65.1"
+    "@aztec/entrypoints" "0.65.1"
+    "@aztec/ethereum" "0.65.1"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/types" "0.65.1"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.65.0.tgz#155829a9968bd178b6b2108435efcd557d78348b"
-  integrity sha512-XMpqyiuWaS9/nAYQs0KLoXDM1Oui31wWn8ogNsOjMuj95pjO6pya6+ztUR93rZNDAtqRdE4HZNFShSsSy837Yg==
+"@aztec/aztec.js@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.65.1.tgz#205f3ae3cd23eaf0135d3162f82f51ed2c329d05"
+  integrity sha512-5hrSv2g4mkvOAf4h+R8FpzEcGFHZFpytWLw9dzyZfOS+rhOGxVTe92m8O3lp5SrqdWAU7KSYNMB/xtyjMCjObw==
   dependencies:
-    "@aztec/circuit-types" "0.65.0"
-    "@aztec/circuits.js" "0.65.0"
-    "@aztec/ethereum" "0.65.0"
-    "@aztec/foundation" "0.65.0"
-    "@aztec/l1-artifacts" "0.65.0"
-    "@aztec/protocol-contracts" "0.65.0"
-    "@aztec/types" "0.65.0"
+    "@aztec/circuit-types" "0.65.1"
+    "@aztec/circuits.js" "0.65.1"
+    "@aztec/ethereum" "0.65.1"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/l1-artifacts" "0.65.1"
+    "@aztec/protocol-contracts" "0.65.1"
+    "@aztec/types" "0.65.1"
     axios "^1.7.2"
     tslib "^2.4.0"
     viem "^2.7.15"
 
-"@aztec/bb.js@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.65.0.tgz#c0f476c687ea8b61cc1b71213ad0a3a84ed25d81"
-  integrity sha512-DBbUN1RThAe72h5SFF2qscUCOxqAow1KLyHVDpH2HX25YoXbs/3q3V1jIwJgDsOH2EsWifCEHBkWmJ90C1ilUw==
+"@aztec/bb.js@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.65.1.tgz#a483601d4e621ee350cfcd57185d2ceee03869f3"
+  integrity sha512-MxHDapvIoOK67/B7IRXMlWNV3Gcih+bmlg+SPCRe8JuO0cXRK2x6dqzTxgbd75u3kNTkyrcBhgXrvNuL9N/C/w==
   dependencies:
     comlink "^4.4.1"
     commander "^10.0.1"
     debug "^4.3.4"
     fflate "^0.8.0"
+    pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/circuit-types@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.65.0.tgz#24d8862ac59b28a0055fda000e37167c27e513db"
-  integrity sha512-DYuUt6skhANQVznn/DbHdR7RyVGM5d+nZwSyWH0v7ekwaYJs0a+//4w2Qgv0729cmiLHk/BJ5CwBjIf4BqP1Ag==
+"@aztec/circuit-types@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.65.1.tgz#abdfc8e180de89145d8fe768d8d6342adc50bc7e"
+  integrity sha512-xNOIvXn5Hu8YCejCfeN8Jx+tAnrohiAhi9jvLDkIRpS3OuCIR3a6Ot+xJQbxOGGXwDyfaDmw7o33rpc3qS5MYA==
   dependencies:
-    "@aztec/circuits.js" "0.65.0"
-    "@aztec/ethereum" "0.65.0"
-    "@aztec/foundation" "0.65.0"
-    "@aztec/types" "0.65.0"
+    "@aztec/circuits.js" "0.65.1"
+    "@aztec/ethereum" "0.65.1"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/types" "0.65.1"
     browserify-cipher "^1.0.1"
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
@@ -72,39 +73,39 @@
     tslib "^2.5.0"
     zod "^3.23.8"
 
-"@aztec/circuits.js@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.65.0.tgz#5c25afdcb39ccde7b9ee77128a76af57113cb1bb"
-  integrity sha512-h1k0kAw+Ffi3vPBCelFY/GiMbR9L+J4hPfaxmF1NVWC1f4MKfDT1GcHnaXhT+3i/eK+rvWu10FZCXxkDWSKryg==
+"@aztec/circuits.js@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.65.1.tgz#072ca55ba7fff075a737de7562dba35a656a5b85"
+  integrity sha512-zxxtkLf4Y4lDCgM/k4ZNWLIlUY/KEDwVKqClkfLYTjlrpO6sMPbQPQGRgrpJZetPi6YLXwUWkm73BhKo6VvXHA==
   dependencies:
-    "@aztec/bb.js" "0.65.0"
-    "@aztec/ethereum" "0.65.0"
-    "@aztec/foundation" "0.65.0"
-    "@aztec/types" "0.65.0"
+    "@aztec/bb.js" "0.65.1"
+    "@aztec/ethereum" "0.65.1"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/types" "0.65.1"
     eslint "^8.35.0"
     lodash.chunk "^4.2.0"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/entrypoints@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.65.0.tgz#8be937d2e9a23899a761efeb77a711a0806d5153"
-  integrity sha512-+jw+AEoKVHBA6fd1jgF++XW2Pe+J1JQMSFGxY6i/5A3Fa0yQXbGLDZTqXGwUzWfHdBaeYDUAzy1+cMCy3WF3kA==
+"@aztec/entrypoints@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.65.1.tgz#46cd2bc5a24fc5c38ee99da922b6293bb16a6315"
+  integrity sha512-qpobFS7I+M4txKOOgByveHZF6RZujPXZ7J5RWAR76zzCfKGrEG2TbH1St1G3nvSFVIbx4CzWlHzcyW28yeGmnA==
   dependencies:
-    "@aztec/aztec.js" "0.65.0"
-    "@aztec/circuit-types" "0.65.0"
-    "@aztec/circuits.js" "0.65.0"
-    "@aztec/foundation" "0.65.0"
-    "@aztec/protocol-contracts" "0.65.0"
+    "@aztec/aztec.js" "0.65.1"
+    "@aztec/circuit-types" "0.65.1"
+    "@aztec/circuits.js" "0.65.1"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/protocol-contracts" "0.65.1"
     tslib "^2.4.0"
 
-"@aztec/ethereum@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.65.0.tgz#cc5ddecfcd8b650f54596f2a969f0ccff908c1ab"
-  integrity sha512-1al7gG0+4cbm8KEvytF4+V0m5oNl8XZLExjFi4WGZH3fFd55pXtveMzXgghVCzQNs5DetmYQeFe05vLA4mctFw==
+"@aztec/ethereum@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.65.1.tgz#1d33b02621ca9756c8b363be477abe31c9355a78"
+  integrity sha512-3arKI8uLJd8uzaLZfcHb0AR28ikAPKSs37wqxrEWnjr9FwBe2XmbgzVjNWbTanyRCJh1dRpzdywGSrxtFZhvyw==
   dependencies:
-    "@aztec/foundation" "0.65.0"
-    "@aztec/l1-artifacts" "0.65.0"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/l1-artifacts" "0.65.1"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     get-port "^7.1.0"
@@ -112,12 +113,12 @@
     viem "^2.7.15"
     zod "^3.23.8"
 
-"@aztec/foundation@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.65.0.tgz#03323b4ec57157533d36769a22df95fcaa784160"
-  integrity sha512-CXiOu2EeQvUAoa38zCpi06KMGe0Byc6zABfwXCLA6slgqiRz0KSkEy79stHz0lXgej1UWHYyNYKpHilDWzlLaQ==
+"@aztec/foundation@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.65.1.tgz#1f401ff5556e7de7995e20c326ee3410fabb6048"
+  integrity sha512-4HYzzw2NpFcSxuEX0alhVyMDGsUJkIFaJBHTy+7gvOR52z4alTKDC1UIpFFCuKzpDiq+iSqmc/m41YO6hBXUGQ==
   dependencies:
-    "@aztec/bb.js" "0.65.0"
+    "@aztec/bb.js" "0.65.1"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "^1.2.0"
     bn.js "^5.2.1"
@@ -138,39 +139,39 @@
     sha3 "^2.1.4"
     zod "^3.23.8"
 
-"@aztec/l1-artifacts@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.65.0.tgz#83eebedacf63a31b8594c43d25237ae22279c075"
-  integrity sha512-d+biinhxmtjvf9+NLeI3D+ubar1nALrnMTZ54eUlupzU/GNjMfJcf9RJvLVkoO/0ZjQPZ3rvCNygady+Wu7s0Q==
+"@aztec/l1-artifacts@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.65.1.tgz#1d7d4cf4b2552e4c0f40405f6753ab3d044b0a3a"
+  integrity sha512-7gjgzB+6FUdTZjUz1372a/Lw/o97L9gC65xaRn7apUjoS2NEJwx8qAnJUzP+2wlZ3bJ7m4CxQoTvIwTfGSx/nA==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/noir-contracts.js@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.65.0.tgz#fdb55a85e3e60b1b228ef510e6f3830410edc857"
-  integrity sha512-38C9CevuKaFCyR+5uy9Vo4uARS4yepxiKPYR+0LOhB+6gdyIP8wSGls+8Zi4jDHLNgPSxdA3matXkZ7/HUgLoA==
+"@aztec/noir-contracts.js@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.65.1.tgz#74f5f89c9c1fa34b54db927d1026890495e6a4f6"
+  integrity sha512-Mi11v03Az9mQXPJzlNCruPzu+gRSnnQVY4m7pnNvVEl4UQTVQi3q6yhN9pDm64zYXxuPlmdnW49s66Mmh7G68g==
   dependencies:
-    "@aztec/aztec.js" "0.65.0"
+    "@aztec/aztec.js" "0.65.1"
     tslib "^2.4.0"
 
-"@aztec/protocol-contracts@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.65.0.tgz#43f937433266c8069777520f02cc86a00e5eb426"
-  integrity sha512-Gra5QRT/WO0nAM8ev16tnD2Nu7DJpkyKsrjXoi97q5kzckIG6/J47MlSd/ekdbDETQMSjJN29TFSplsTR9gh5A==
+"@aztec/protocol-contracts@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.65.1.tgz#cc897c05197efab6220f86f053bd86ec51d487da"
+  integrity sha512-84cdnPxqEYhAgaibBzkD9eysU7oeuwvskRga2RYLDiU71sdYRuOipvOJun+pVle//Q7ceGS1I4hiAdkzeGk+wg==
   dependencies:
-    "@aztec/circuits.js" "0.65.0"
-    "@aztec/foundation" "0.65.0"
-    "@aztec/types" "0.65.0"
+    "@aztec/circuits.js" "0.65.1"
+    "@aztec/foundation" "0.65.1"
+    "@aztec/types" "0.65.1"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/types@0.65.0":
-  version "0.65.0"
-  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.65.0.tgz#dd9b1b2482e0d04168c518a343b2fb759a8295f7"
-  integrity sha512-eeGRdhJfD8ALWbLn3HR8Hb0MMG5CUR3yvIbQIF5z7r+Am8gOqMCa6asJY345vK9WtkZXmlsVZgL860dRh5l6gg==
+"@aztec/types@0.65.1":
+  version "0.65.1"
+  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.65.1.tgz#219cf2196c922bf20d0fdaedd053143b2c331de1"
+  integrity sha512-pcRd+hamxPS1QpeFdvN0GT7eJttZ4ufvUaKj3k/95DrMcCPIhnFt/EOd4oS9peVRfPS6dfkVKE0EuO2rg226Vg==
   dependencies:
-    "@aztec/ethereum" "0.65.0"
-    "@aztec/foundation" "0.65.0"
+    "@aztec/ethereum" "0.65.1"
+    "@aztec/foundation" "0.65.1"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7":
   version "7.24.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,40 +15,40 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aztec/accounts@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.63.1.tgz#7b11b7880366b9f4cf2f16b6f65e7a616da662d6"
-  integrity sha512-RR+WH6Xv2u7kc1aWgQe62dCa2yCMjYIm2Ear+vOOfcT6aCZEVAt5lzXV61fd0VNjAXOUkqNuOh0XsCk/+liFOg==
+"@aztec/accounts@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.65.0.tgz#50a37ddb386d7a9dc2bd40260b5c3abb535ffcb8"
+  integrity sha512-bmCSoe6TtHVbRhhSeDdVaTEzpJ8ZR1C1ZhdtHATLX5sbfkod/whNYnTwbXfnu76cIXAROiAX6tqKYrsTDIAIuA==
   dependencies:
-    "@aztec/aztec.js" "0.63.1"
-    "@aztec/circuit-types" "0.63.1"
-    "@aztec/circuits.js" "0.63.1"
-    "@aztec/entrypoints" "0.63.1"
-    "@aztec/ethereum" "0.63.1"
-    "@aztec/foundation" "0.63.1"
-    "@aztec/types" "0.63.1"
+    "@aztec/aztec.js" "0.65.0"
+    "@aztec/circuit-types" "0.65.0"
+    "@aztec/circuits.js" "0.65.0"
+    "@aztec/entrypoints" "0.65.0"
+    "@aztec/ethereum" "0.65.0"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/types" "0.65.0"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.63.1.tgz#0c5ac2aebb16c6e3a2d83e50324a32a8e300debf"
-  integrity sha512-HyCQP+oLStxcFbGB2c9DurSelQNnn5DksE1Ts41RxxptBy0Sa2gQC+LZ4Us6c4pE6YFZRMs4+t3vQ+ylLjkvrg==
+"@aztec/aztec.js@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.65.0.tgz#155829a9968bd178b6b2108435efcd557d78348b"
+  integrity sha512-XMpqyiuWaS9/nAYQs0KLoXDM1Oui31wWn8ogNsOjMuj95pjO6pya6+ztUR93rZNDAtqRdE4HZNFShSsSy837Yg==
   dependencies:
-    "@aztec/circuit-types" "0.63.1"
-    "@aztec/circuits.js" "0.63.1"
-    "@aztec/ethereum" "0.63.1"
-    "@aztec/foundation" "0.63.1"
-    "@aztec/l1-artifacts" "0.63.1"
-    "@aztec/protocol-contracts" "0.63.1"
-    "@aztec/types" "0.63.1"
+    "@aztec/circuit-types" "0.65.0"
+    "@aztec/circuits.js" "0.65.0"
+    "@aztec/ethereum" "0.65.0"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/l1-artifacts" "0.65.0"
+    "@aztec/protocol-contracts" "0.65.0"
+    "@aztec/types" "0.65.0"
     axios "^1.7.2"
     tslib "^2.4.0"
     viem "^2.7.15"
 
-"@aztec/bb.js@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.63.1.tgz#331ce6532969ef790eca4623398baa7f7ca1ab37"
-  integrity sha512-pSWh1PsOZISVpdbJch1gXUAa3jfohL6IhbjGKjaRY1QaLf3Fnz33AomB/vqAZs7Uy2VMVqlDdbc9b1QUHTcpzQ==
+"@aztec/bb.js@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.65.0.tgz#c0f476c687ea8b61cc1b71213ad0a3a84ed25d81"
+  integrity sha512-DBbUN1RThAe72h5SFF2qscUCOxqAow1KLyHVDpH2HX25YoXbs/3q3V1jIwJgDsOH2EsWifCEHBkWmJ90C1ilUw==
   dependencies:
     comlink "^4.4.1"
     commander "^10.0.1"
@@ -56,15 +56,15 @@
     fflate "^0.8.0"
     tslib "^2.4.0"
 
-"@aztec/circuit-types@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.63.1.tgz#6f3e323af6dd75c5d109048bda9dc7bec1f26d91"
-  integrity sha512-dg7v9uTiY3DGkDZGtfUhSCleU+ep8NY8Z4qUpBSwnQqd5JoD1R+s8EHvDxbPF8syIavFMQi0TNfa9hpI5TOj4Q==
+"@aztec/circuit-types@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.65.0.tgz#24d8862ac59b28a0055fda000e37167c27e513db"
+  integrity sha512-DYuUt6skhANQVznn/DbHdR7RyVGM5d+nZwSyWH0v7ekwaYJs0a+//4w2Qgv0729cmiLHk/BJ5CwBjIf4BqP1Ag==
   dependencies:
-    "@aztec/circuits.js" "0.63.1"
-    "@aztec/ethereum" "0.63.1"
-    "@aztec/foundation" "0.63.1"
-    "@aztec/types" "0.63.1"
+    "@aztec/circuits.js" "0.65.0"
+    "@aztec/ethereum" "0.65.0"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/types" "0.65.0"
     browserify-cipher "^1.0.1"
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
@@ -72,50 +72,52 @@
     tslib "^2.5.0"
     zod "^3.23.8"
 
-"@aztec/circuits.js@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.63.1.tgz#b9df9dcd66fdc76c5c554fac548bdd1db45b0b66"
-  integrity sha512-HNL501VbyI31UJZRM29nIGm42lbjMiRzGGNW/YLJml8DhWj5f1IXaDRa6JescyWNAYtJ+dTllOpbINn4TwR7fw==
+"@aztec/circuits.js@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.65.0.tgz#5c25afdcb39ccde7b9ee77128a76af57113cb1bb"
+  integrity sha512-h1k0kAw+Ffi3vPBCelFY/GiMbR9L+J4hPfaxmF1NVWC1f4MKfDT1GcHnaXhT+3i/eK+rvWu10FZCXxkDWSKryg==
   dependencies:
-    "@aztec/bb.js" "0.63.1"
-    "@aztec/ethereum" "0.63.1"
-    "@aztec/foundation" "0.63.1"
-    "@aztec/types" "0.63.1"
+    "@aztec/bb.js" "0.65.0"
+    "@aztec/ethereum" "0.65.0"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/types" "0.65.0"
     eslint "^8.35.0"
     lodash.chunk "^4.2.0"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/entrypoints@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.63.1.tgz#5211b07e823517e184b9b77221b56764165c4c00"
-  integrity sha512-Mou1GYf2cfl/QXSKSmIRocL9hwcmLRVZ7dsuizLVXkD05rdhjHQNePsvejv5MXqESEop9GNEOkJdWdZPepBF2A==
+"@aztec/entrypoints@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.65.0.tgz#8be937d2e9a23899a761efeb77a711a0806d5153"
+  integrity sha512-+jw+AEoKVHBA6fd1jgF++XW2Pe+J1JQMSFGxY6i/5A3Fa0yQXbGLDZTqXGwUzWfHdBaeYDUAzy1+cMCy3WF3kA==
   dependencies:
-    "@aztec/aztec.js" "0.63.1"
-    "@aztec/circuit-types" "0.63.1"
-    "@aztec/circuits.js" "0.63.1"
-    "@aztec/foundation" "0.63.1"
-    "@aztec/protocol-contracts" "0.63.1"
+    "@aztec/aztec.js" "0.65.0"
+    "@aztec/circuit-types" "0.65.0"
+    "@aztec/circuits.js" "0.65.0"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/protocol-contracts" "0.65.0"
     tslib "^2.4.0"
 
-"@aztec/ethereum@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.63.1.tgz#dcdb085d74e77e57c76504bf6ff152c2d32d034e"
-  integrity sha512-NXjbk3ctoqRqXKOd4jctHwJxgxqgHhD3AYH/pzMGy13+mBdh1wVZD/2JwEPRnKOGz5coGpom+rTno1LkpYUZcQ==
+"@aztec/ethereum@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.65.0.tgz#cc5ddecfcd8b650f54596f2a969f0ccff908c1ab"
+  integrity sha512-1al7gG0+4cbm8KEvytF4+V0m5oNl8XZLExjFi4WGZH3fFd55pXtveMzXgghVCzQNs5DetmYQeFe05vLA4mctFw==
   dependencies:
-    "@aztec/foundation" "0.63.1"
-    "@aztec/l1-artifacts" "0.63.1"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/l1-artifacts" "0.65.0"
+    "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
+    get-port "^7.1.0"
     tslib "^2.4.0"
     viem "^2.7.15"
     zod "^3.23.8"
 
-"@aztec/foundation@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.63.1.tgz#153cc250d11265b43f57ba7cb3df616cac4863c2"
-  integrity sha512-ElCNZL/1cvaebE0hG0crbQHN3rBhKVI5CN/JhC+RtFvYM+yR2r5VLCXlIVYb5Qz8jssVhLfoT1z/FVuZOAW+rg==
+"@aztec/foundation@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.65.0.tgz#03323b4ec57157533d36769a22df95fcaa784160"
+  integrity sha512-CXiOu2EeQvUAoa38zCpi06KMGe0Byc6zABfwXCLA6slgqiRz0KSkEy79stHz0lXgej1UWHYyNYKpHilDWzlLaQ==
   dependencies:
-    "@aztec/bb.js" "0.63.1"
+    "@aztec/bb.js" "0.65.0"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "^1.2.0"
     bn.js "^5.2.1"
@@ -136,39 +138,39 @@
     sha3 "^2.1.4"
     zod "^3.23.8"
 
-"@aztec/l1-artifacts@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.63.1.tgz#0c5e50d20404a6b34ab478bad46ea6fb92607ea3"
-  integrity sha512-rJ3wCPMbfmBLx6qRHHGnrYVpMmjpwSfKjk9Ti2ZK9xZaBXueoq7tJRM5tmkiQjBXQLWImWH474OX6JTWbV7Wug==
+"@aztec/l1-artifacts@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.65.0.tgz#83eebedacf63a31b8594c43d25237ae22279c075"
+  integrity sha512-d+biinhxmtjvf9+NLeI3D+ubar1nALrnMTZ54eUlupzU/GNjMfJcf9RJvLVkoO/0ZjQPZ3rvCNygady+Wu7s0Q==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/noir-contracts.js@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.63.1.tgz#6bd324bdcfd3c29510ac39f8ef79130353914003"
-  integrity sha512-ZNb17Vkwn2vDTWM4JmUWmnQMHn/vcLwrYu3wn7e8k+egE5M3Hlh0Rrcmdnp9St0cWPZ85Zx7HvqOiPGYAN6cZA==
+"@aztec/noir-contracts.js@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.65.0.tgz#fdb55a85e3e60b1b228ef510e6f3830410edc857"
+  integrity sha512-38C9CevuKaFCyR+5uy9Vo4uARS4yepxiKPYR+0LOhB+6gdyIP8wSGls+8Zi4jDHLNgPSxdA3matXkZ7/HUgLoA==
   dependencies:
-    "@aztec/aztec.js" "0.63.1"
+    "@aztec/aztec.js" "0.65.0"
     tslib "^2.4.0"
 
-"@aztec/protocol-contracts@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.63.1.tgz#27e4cd56dec03867c4889603591b81e6c6aa3d5a"
-  integrity sha512-Xg3i1jZnQ+nHEkhkFNgQ8sNKTTVJCxAjVJ3xhJv595WpPg4Eay2kcI7biDIyJDLG5LRZTtzHvyJblHzKeisgrg==
+"@aztec/protocol-contracts@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.65.0.tgz#43f937433266c8069777520f02cc86a00e5eb426"
+  integrity sha512-Gra5QRT/WO0nAM8ev16tnD2Nu7DJpkyKsrjXoi97q5kzckIG6/J47MlSd/ekdbDETQMSjJN29TFSplsTR9gh5A==
   dependencies:
-    "@aztec/circuits.js" "0.63.1"
-    "@aztec/foundation" "0.63.1"
-    "@aztec/types" "0.63.1"
+    "@aztec/circuits.js" "0.65.0"
+    "@aztec/foundation" "0.65.0"
+    "@aztec/types" "0.65.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/types@0.63.1":
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.63.1.tgz#785214bcdd95f47dfce18ea11e4f16fd8ae62474"
-  integrity sha512-FdjTjvMxmr6/Mzrrjdam/y/mRYKW6ZzaWNRExvCcu10nSu8FU/T+4Jz8OiraIvhfK6aF4bG3N4/CZ2AwMryURA==
+"@aztec/types@0.65.0":
+  version "0.65.0"
+  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.65.0.tgz#dd9b1b2482e0d04168c518a343b2fb759a8295f7"
+  integrity sha512-eeGRdhJfD8ALWbLn3HR8Hb0MMG5CUR3yvIbQIF5z7r+Am8gOqMCa6asJY345vK9WtkZXmlsVZgL860dRh5l6gg==
   dependencies:
-    "@aztec/ethereum" "0.63.1"
-    "@aztec/foundation" "0.63.1"
+    "@aztec/ethereum" "0.65.0"
+    "@aztec/foundation" "0.65.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7":
   version "7.24.7"
@@ -982,6 +984,16 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
+
+"@viem/anvil@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@viem/anvil/-/anvil-0.0.10.tgz#aa64fd96017d6875c9e8bebc223d394a55bc3a72"
+  integrity sha512-9PzYXBRikfSUhhm8Bd0avv07agwcbMJ5FaSu2D2vbE0cxkvXGtolL3fW5nz2yefMqOqVQL4XzfM5nwY81x3ytw==
+  dependencies:
+    execa "^7.1.1"
+    get-port "^6.1.2"
+    http-proxy "^1.18.1"
+    ws "^8.13.0"
 
 abitype@1.0.5:
   version "1.0.5"
@@ -1826,6 +1838,11 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+eventemitter3@^4.0.0:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
+  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
@@ -1848,6 +1865,21 @@ execa@^5.0.0:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+execa@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-7.2.0.tgz#657e75ba984f42a70f38928cedc87d6f2d4fe4e9"
+  integrity sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.1"
+    human-signals "^4.3.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^3.0.7"
+    strip-final-newline "^3.0.0"
 
 exit@^0.1.2:
   version "0.1.2"
@@ -1950,6 +1982,11 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
+follow-redirects@^1.0.0:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
 follow-redirects@^1.15.6:
   version "1.15.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.8.tgz#ae67b97ae32e0a7b36066a5448938374ec18d13d"
@@ -2015,7 +2052,17 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-stream@^6.0.0:
+get-port@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
+  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
+
+get-port@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-7.1.0.tgz#d5a500ebfc7aa705294ec2b83cc38c5d0e364fec"
+  integrity sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==
+
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -2170,10 +2217,24 @@ http-errors@^1.6.3, http-errors@^1.8.1, http-errors@~1.8.0:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.1"
 
+http-proxy@^1.18.1:
+  version "1.18.1"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
+  integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
+human-signals@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
+  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -2291,6 +2352,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -3083,6 +3149,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
@@ -3154,6 +3225,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
+  dependencies:
+    path-key "^4.0.0"
+
 object-inspect@^1.13.1:
   version "1.13.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
@@ -3179,6 +3257,13 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
 
 only@~0.0.2:
   version "0.0.2"
@@ -3271,6 +3356,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-parse@^1.0.7:
   version "1.0.7"
@@ -3381,6 +3471,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -3604,6 +3699,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-json-comments@^3.1.1:
   version "3.1.1"
@@ -3868,6 +3968,11 @@ ws@8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
+ws@^8.13.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
currenlty failing `yarn test` with the following error:

```
txe-1          | Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'jest-mock-extended' imported from /usr/src/yarn-project/simulator/dest/public/fixtures/index.js
txe-1          |     at new NodeError (node:internal/errors:405:5)
txe-1          |     at packageResolve (node:internal/modules/esm/resolve:916:9)
txe-1          |     at moduleResolve (node:internal/modules/esm/resolve:973:20)
txe-1          |     at defaultResolve (node:internal/modules/esm/resolve:1193:11)
txe-1          |     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:403:12)
txe-1          |     at ModuleLoader.resolve (node:internal/modules/esm/loader:372:25)
txe-1          |     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:249:38)
txe-1          |     at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:76:39)
txe-1          |     at link (node:internal/modules/esm/module_job:75:36) {
txe-1          |   code: 'ERR_MODULE_NOT_FOUND'
txe-1          | }
txe-1          | 
txe-1          | Node.js v18.19.1
txe-1 exited with code 1
```