### PR TITLE
feat: reusing deployed contract in js test

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "compile": "${AZTEC_NARGO:-aztec-nargo} compile",
     "deploy": "node --loader ts-node/esm scripts/deploy.ts",
     "get-block": "node --loader ts-node/esm scripts/getBlock.ts",
-    "test": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json && aztec test",
+    "test": "yarn test:js && yarn test:nr",
+    "test:js": "NODE_NO_WARNINGS=1 node --experimental-vm-modules $(yarn bin jest) --no-cache --runInBand --config jest.integration.config.json",
+    "test:nr": "aztec test",
     "update": "aztec update --contract . && ./.github/scripts/update_contract.sh $(grep -oP 'tag\\s*=\\s*\"\\K[^\"]+' \"Nargo.toml\" | head -1) && yarn"
   },
   "dependencies": {

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -1,5 +1,5 @@
-import { EasyPrivateVotingContractArtifact, EasyPrivateVotingContract } from "../artifacts/EasyPrivateVoting.js"
-import { AccountWallet, CompleteAddress, ContractDeployer, createDebugLogger, Fr, PXE, waitForPXE, TxStatus, createPXEClient, getContractInstanceFromDeployParams, DebugLogger, Contract } from "@aztec/aztec.js";
+import { EasyPrivateVotingContractArtifact } from "../artifacts/EasyPrivateVoting.js"
+import { AccountWallet, ContractDeployer, createDebugLogger, Fr, PXE, waitForPXE, TxStatus, createPXEClient, getContractInstanceFromDeployParams, DebugLogger, Contract } from "@aztec/aztec.js";
 import { getInitialTestAccountsWallets } from "@aztec/accounts/testing"
 
 const setupSandbox = async () => {
@@ -12,7 +12,6 @@ const setupSandbox = async () => {
 describe("Voting", () => {
     let pxe: PXE;
     let wallets: AccountWallet[] = [];
-    let accounts: CompleteAddress[] = [];
     let logger: DebugLogger;
     let contract: Contract
     let candidate: Fr
@@ -25,7 +24,6 @@ describe("Voting", () => {
         candidate = new Fr(1);
 
         wallets = await getInitialTestAccountsWallets(pxe);
-        accounts = wallets.map(w => w.getCompleteAddress())
     })
 
     it("Deploys the contract", async () => {


### PR DESCRIPTION
Avoiding re-deploying the contract on each `it` instance, they are executed sequentially on the same PXE. It's a bit inconvenient for certain tests tho.
I'm just trying to understand why i cannot re-use them in my custom program, getting `No public key registered for address` error