### PR TITLE
fix: jest warning

### DIFF
--- a/jest.integration.config.json
+++ b/jest.integration.config.json
@@ -1,9 +1,7 @@
 {
   "preset": "ts-jest/presets/default-esm",
-  "globals": {
-    "ts-jest": {
-      "useESM": true
-    }
+  "transform": {
+    "^.+\\.tsx?$": ["ts-jest", { "useESM": true }]
   },
   "moduleNameMapper": {
     "^(\\.{1,2}/.*)\\.js$": "$1"


### PR DESCRIPTION
solves the following warning when testing with jest
```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```