### PR TITLE
fix: Incorrect usage of the `assert` macro

### DIFF
--- a/src/test/first.nr
+++ b/src/test/first.nr
@@ -11,7 +11,7 @@ unconstrained fn test_initializer() {
     let block_number = get_block_number();
     let admin_slot = EasyPrivateVoting::storage_layout().admin.slot;
     let admin_storage_value = storage_read(voting_contract_address, admin_slot, block_number);
-    assert(admin_storage_value == admin, "Vote ended should be false");
+    assert!(admin_storage_value == admin, "Vote ended should be false");
 }
 
 #[test]
@@ -23,7 +23,7 @@ unconstrained fn test_check_vote_status() {
     let block_number = get_block_number();
     let status_slot = EasyPrivateVoting::storage_layout().vote_ended.slot;
     let vote_ended_read: bool = storage_read(voting_contract_address, status_slot, block_number);
-    assert(vote_ended_expected == vote_ended_read, "Vote ended should be false");
+    assert!(vote_ended_expected == vote_ended_read, "Vote ended should be false");
 }
 
 #[test]
@@ -38,7 +38,7 @@ unconstrained fn test_end_vote() {
     let block_number = get_block_number();
     let status_slot = EasyPrivateVoting::storage_layout().vote_ended.slot;
     let vote_ended_read: bool = storage_read(voting_contract_address, status_slot, block_number);
-    assert(vote_ended_expected == vote_ended_read, "Vote ended should be true");
+    assert!(vote_ended_expected == vote_ended_read, "Vote ended should be true");
 }
 
 #[test(should_fail)]
@@ -66,7 +66,7 @@ unconstrained fn test_cast_vote() {
     let candidate_tally_slot = derive_storage_slot_in_map(tally_slot, candidate);
     let vote_count: u32 = storage_read(voting_contract_address, candidate_tally_slot, block_number);
 
-    assert(vote_count == 1, "vote tally should be incremented");
+    assert!(vote_count == 1, "vote tally should be incremented");
 }
 
 #[test]
@@ -91,7 +91,7 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
     let candidate_tally_slot = derive_storage_slot_in_map(tally_slot, candidate);
     let vote_count: u32 = storage_read(voting_contract_address, candidate_tally_slot, block_number);
 
-    assert(vote_count == 2, "vote tally should be 2");
+    assert!(vote_count == 2, "vote tally should be 2");
 }
 
 #[test(should_fail)]


### PR DESCRIPTION
In Rust, it is recommended to use the `assert!` macro when verifying a boolean expression. The `assert!` macro is specifically designed for checking expressions, and its usage makes the intent of the code clearer and more explicit.

Using a comparison expression directly in `assert` might be perceived as a standalone statement rather than a proper boolean check.