### PR TITLE
Fix type mismatch in `storage_read` return value

### DIFF
--- a/src/test/first.nr
+++ b/src/test/first.nr
@@ -22,7 +22,7 @@ unconstrained fn test_check_vote_status() {
 
     let block_number = get_block_number();
     let status_slot = EasyPrivateVoting::storage_layout().vote_ended.slot;
-    let vote_ended_read: bool = storage_read(voting_contract_address, status_slot, block_number);
+    let vote_ended_read: Field = storage_read(voting_contract_address, status_slot, block_number);
     assert(vote_ended_expected == vote_ended_read, "Vote ended should be false");
 }
 


### PR DESCRIPTION
## Description

The variable type `vote_ended_read` is defined as `bool`. However, the `storage_read` method typically returns a generic type like `Field`, not a specific primitive such as `bool`. This may lead to a compilation error if the types are incompatible or a runtime panic if the type is not converted properly.