### PR TITLE
Fix broken link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Then test with:
 yarn test
 ```
 
-Testing will run the Typescript tests defined in `index.test.ts` file in the `./src/test` directory, as well as the [Aztec Testing eXecution Environment (TXE)](https://docs.aztec.network/guides/developer_guides/smart_contracts/testing_contracts/testing) tests defined in [`first.nr`](./src/test/first.nr) (and imported at the top of the contract file with `mod test;`).
+Testing will run the Typescript tests defined in `index.test.ts` file in the `./src/test` directory, as well as the [Aztec Testing eXecution Environment (TXE)](https://docs.aztec.network/guides/developer_guides/smart_contracts/testing) tests defined in [`first.nr`](./src/test/first.nr) (and imported at the top of the contract file with `mod test;`).
 
 ## Error resolution
 


### PR DESCRIPTION
# Fix Broken Link in README.md

## Description

This pull request resolves a broken link in the `README.md` file, ensuring accurate navigation to documentation resources.

### Summary of Changes

#### **File:** `README.md`
- **Issue:** Broken link in the "Testing" section.
  - **Original Link:** `https://docs.aztec.network/guides/developer_guides/smart_contracts/testing_contracts/testing`
  - **Updated Link:** Corrected to a working URL for the Aztec Testing eXecution Environment (TXE) documentation.

### Why This Fix Is Important

- Ensures developers can access the correct documentation without confusion or delay.
- Maintains the integrity and usability of the `README.md` file.
- Improves the onboarding experience for new contributors or users.

---

## Checklist

- [x] Verified the corrected link navigates to the intended documentation.
- [x] No other parts of the file were modified.
- [x] Adhered to the [GitHub Community Guidelines](https://docs.github.com/en/get-started/quickstart/contributing-to-projects).

---

### Notes for Reviewers

This is a minor fix focused solely on updating a broken link. Please review and merge at your convenience. If there are additional documentation updates required, I am happy to address them in a follow-up PR.

Thank you!
