### PR TITLE
Update starter with v0.76.0

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,4 @@ authors = [ "" ]
 compiler_version = ">=0.18.0"
 
 [dependencies]
-aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.74.0", directory = "noir-projects/aztec-nr/aztec" }
+aztec = { git = "https://github.com/AztecProtocol/aztec-packages/", tag = "aztec-packages-v0.76.0", directory = "noir-projects/aztec-nr/aztec" }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bash -i <(curl -s https://install.aztec.network)
 Install the correct version of the toolkit with:
 
 ```bash
-aztec-up 0.74.0
+aztec-up 0.76.0
 ```
 
 Start the sandbox with:

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "update-readme-version": "node ./.github/scripts/update-readme-version.js"
   },
   "dependencies": {
-    "@aztec/accounts": "0.74.0",
-    "@aztec/aztec.js": "0.74.0",
-    "@aztec/noir-contracts.js": "0.74.0",
+    "@aztec/accounts": "0.76.0",
+    "@aztec/aztec.js": "0.76.0",
+    "@aztec/noir-contracts.js": "0.76.0",
     "@types/node": "^22.5.1"
   },
   "devDependencies": {

--- a/src/test/first.nr
+++ b/src/test/first.nr
@@ -44,7 +44,7 @@ unconstrained fn test_end_vote() {
 #[test(should_fail)]
 unconstrained fn test_fail_end_vote_by_non_admin() {
     let (env, voting_contract_address, _) = utils::setup();
-    let alice = env.create_account();
+    let alice = env.create_account(1);
 
     env.impersonate(alice);
     EasyPrivateVoting::at(voting_contract_address).end_vote().call(&mut env.public());
@@ -53,7 +53,7 @@ unconstrained fn test_fail_end_vote_by_non_admin() {
 #[test]
 unconstrained fn test_cast_vote() {
     let (env, voting_contract_address, _) = utils::setup();
-    let alice = env.create_account();
+    let alice = env.create_account(1);
     env.impersonate(alice);
 
     let candidate = 1;
@@ -72,8 +72,8 @@ unconstrained fn test_cast_vote() {
 #[test]
 unconstrained fn test_cast_vote_with_separate_accounts() {
     let (env, voting_contract_address, _) = utils::setup();
-    let alice = env.create_account();
-    let bob = env.create_account();
+    let alice = env.create_account(1);
+    let bob = env.create_account(2);
 
     let candidate = 101;
 
@@ -97,7 +97,7 @@ unconstrained fn test_cast_vote_with_separate_accounts() {
 #[test(should_fail)]
 unconstrained fn test_fail_vote_twice() {
     let (env, voting_contract_address, _) = utils::setup();
-    let alice = env.create_account();
+    let alice = env.create_account(1);
 
     let candidate = 101;
 

--- a/src/test/utils.nr
+++ b/src/test/utils.nr
@@ -5,7 +5,7 @@ use crate::EasyPrivateVoting;
 pub unconstrained fn setup() -> (&mut TestEnvironment, AztecAddress, AztecAddress) {
     let mut env = TestEnvironment::new();
 
-    let admin = env.create_account();
+    let admin = env.create_account(0);
 
     let initializer_call_interface = EasyPrivateVoting::interface().constructor(admin);
     let voting_contract = env.deploy_self("EasyPrivateVoting").with_public_void_initializer(

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,40 +15,40 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@aztec/accounts@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.74.0.tgz#1afe3031585c2f0eeaa38cb0d7d0de3df018de27"
-  integrity sha512-XqfeFR5UHfAAwq4uEWc07MIKslb8ZxPNQEVsTNSJgYHQ6wrizXPFTQLChMyyPgcZZIkEFJJnq2EecYhidL24Wg==
+"@aztec/accounts@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/accounts/-/accounts-0.76.0.tgz#cfbea5beb4bdd02da3d80b60fc2d6c738f4d18bc"
+  integrity sha512-A38+86qfYf6gfousK1589SCfe+usHCCh12rR1SkAPq/yh/NmGOZ0u0RGK+EGI84opTaelg/pofkrycQSS6/1WA==
   dependencies:
-    "@aztec/aztec.js" "0.74.0"
-    "@aztec/circuit-types" "0.74.0"
-    "@aztec/circuits.js" "0.74.0"
-    "@aztec/entrypoints" "0.74.0"
-    "@aztec/ethereum" "0.74.0"
-    "@aztec/foundation" "0.74.0"
-    "@aztec/types" "0.74.0"
+    "@aztec/aztec.js" "0.76.0"
+    "@aztec/circuit-types" "0.76.0"
+    "@aztec/circuits.js" "0.76.0"
+    "@aztec/entrypoints" "0.76.0"
+    "@aztec/ethereum" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/types" "0.76.0"
     tslib "^2.4.0"
 
-"@aztec/aztec.js@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.74.0.tgz#e2003e539e0bb329430daec5727dd77835093fcc"
-  integrity sha512-VSSeL5s7z/0t8xttz7h8owoyaEFHEKmgwwk1+WL+hUroLmwxTYphu9WpdwMCOwFHtRsjYXmhmMbgtTYfRO53IA==
+"@aztec/aztec.js@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/aztec.js/-/aztec.js-0.76.0.tgz#cc264125e5ffd6abf54d06e14bdd8f399fb141d3"
+  integrity sha512-wV02FrFdUmwyUgdNbjXJmk2RHQAqPKgyZDJddo0AQI1BZL4i7v3OFgPiyfASK2guqLn1qN8sKt6IxlBdEg9OiQ==
   dependencies:
-    "@aztec/circuit-types" "0.74.0"
-    "@aztec/circuits.js" "0.74.0"
-    "@aztec/ethereum" "0.74.0"
-    "@aztec/foundation" "0.74.0"
-    "@aztec/l1-artifacts" "0.74.0"
-    "@aztec/protocol-contracts" "0.74.0"
-    "@aztec/types" "0.74.0"
+    "@aztec/circuit-types" "0.76.0"
+    "@aztec/circuits.js" "0.76.0"
+    "@aztec/ethereum" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/l1-artifacts" "0.76.0"
+    "@aztec/protocol-contracts" "0.76.0"
+    "@aztec/types" "0.76.0"
     axios "^1.7.2"
     tslib "^2.4.0"
     viem "2.22.8"
 
-"@aztec/bb.js@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.74.0.tgz#261a8438b5bc9ca54b13256a42d62e388d1e08a1"
-  integrity sha512-hdFfAqjiy5xbqcNHXlnfRHqLGrlKz2nTq+5FiIUFLYZvBvfv4FilI7psy1dp0kSihFh5cjhatXwiQN1uRIAqNQ==
+"@aztec/bb.js@0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2", "@aztec/bb.js@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/bb.js/-/bb.js-0.76.0.tgz#320922ad007183333eb891b8dd24ef5dcfc67256"
+  integrity sha512-YhRPn4Weo2q+Y/Ng+KAUHaHqjPCwsW2VkH5vDzOa85+J6mPH99LladxqxYb0Vb3rOgF50ou6ARvasmPhOgvpTA==
   dependencies:
     comlink "^4.4.1"
     commander "^12.1.0"
@@ -57,15 +57,24 @@
     pako "^2.1.0"
     tslib "^2.4.0"
 
-"@aztec/circuit-types@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.74.0.tgz#8bb19a821f2f1462f35ce88d854a7963f97eb1a3"
-  integrity sha512-A3HmcOLz4B6e5kaacu0ZIQSgZUI4rIiWc/aydSOh7OBKrgPCaIIEdobPqfHv/M5pgR5q4KrDCgJlRQxBq1UC6g==
+"@aztec/blob-lib@0.76.0":
+  version "0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2"
+  resolved "https://registry.yarnpkg.com/@aztec/blob-lib/-/blob-lib-0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2.tgz#e086de4bb158b0b370414f99bdff5dd9d49276db"
+  integrity sha512-PEwajALJ1BtwjA5rxR6hF0fups80G97gLwXdaYZWfkW1yqaMde0CpQYxAnLZ/xycrh+2B1mhEGh6NXCf7D6jyQ==
   dependencies:
-    "@aztec/circuits.js" "0.74.0"
-    "@aztec/ethereum" "0.74.0"
-    "@aztec/foundation" "0.74.0"
-    "@aztec/types" "0.74.0"
+    "@aztec/foundation" "0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2"
+    c-kzg "4.0.0-alpha.1"
+    tslib "^2.4.0"
+
+"@aztec/circuit-types@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/circuit-types/-/circuit-types-0.76.0.tgz#73f12479fa62f6f7800a18bcdb6a61c42e1ee724"
+  integrity sha512-syc/Xd7Uwg8yqz+17QbvJNInnYRY8J8LwclZDyupyRU4gmfNHy6DXV6dLAcS2OUKYEd8YfubpH9ckX4ylZENaA==
+  dependencies:
+    "@aztec/circuits.js" "0.76.0"
+    "@aztec/ethereum" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/types" "0.76.0"
     browserify-cipher "^1.0.1"
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
@@ -73,50 +82,52 @@
     tslib "^2.5.0"
     zod "^3.23.8"
 
-"@aztec/circuits.js@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.74.0.tgz#030a789dc99680ad01f0170b97994d8958e34d70"
-  integrity sha512-GdsiyymQbPdWeboqPozQRtIaffgZWmjiC7HN9QLLRpdwZDgBSgTRMBeUNNrDoZQ7VxETQY2BYLNY7vkgnESV9w==
+"@aztec/circuits.js@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/circuits.js/-/circuits.js-0.76.0.tgz#e753626753f60c63e5b70d4ec4f69245d2f0b78e"
+  integrity sha512-KK4baawPEpZid/Z08zoMIY/ukAVn/kHnyCUcR8asf5/IJJFGIkeW5diFWSCh+/Y2xdSa4IdW3RcTuxhuCMkUZw==
   dependencies:
-    "@aztec/bb.js" "0.74.0"
-    "@aztec/ethereum" "0.74.0"
-    "@aztec/foundation" "0.74.0"
-    "@aztec/types" "0.74.0"
+    "@aztec/bb.js" "0.76.0"
+    "@aztec/blob-lib" "0.76.0"
+    "@aztec/ethereum" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/types" "0.76.0"
     msgpackr "^1.11.2"
     tslib "^2.4.0"
     zod "^3.23.8"
 
-"@aztec/entrypoints@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.74.0.tgz#3f6de580b72e33944783882cd247c5b30b1a012a"
-  integrity sha512-xt6On6+piauJFQpTTXWhca/iTxIBJa9C442IW2G6wWPpkQV8nB4YMUyosTOIugH8dLxtfjdtqhF8rF94yFsyjQ==
+"@aztec/entrypoints@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/entrypoints/-/entrypoints-0.76.0.tgz#e84a1c7a87808e592da42d0dbdb8e18f4f3daad7"
+  integrity sha512-koGVwsLPw4tF92V3E0hdUp2ImYEhXtpxcrl/lLDeCVfNg+5B3q1RAjqt76HOrzpSI6NMalqqUu4TXubE1TnRiw==
   dependencies:
-    "@aztec/aztec.js" "0.74.0"
-    "@aztec/circuit-types" "0.74.0"
-    "@aztec/circuits.js" "0.74.0"
-    "@aztec/foundation" "0.74.0"
-    "@aztec/protocol-contracts" "0.74.0"
+    "@aztec/aztec.js" "0.76.0"
+    "@aztec/circuit-types" "0.76.0"
+    "@aztec/circuits.js" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/protocol-contracts" "0.76.0"
     tslib "^2.4.0"
 
-"@aztec/ethereum@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.74.0.tgz#1eec6e0ca8227ef15a111c73660929a9bad543e4"
-  integrity sha512-gfJ5GaLT7xUrijm6y45nFTVJ1K5U1QWNdJVCUI3NKl7J3nZ0C5Xu39ZlcRBKm3S2iHHbyGbsRG4QmV+LsD0M1Q==
+"@aztec/ethereum@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/ethereum/-/ethereum-0.76.0.tgz#e84280262427a3ee1082756e24eaf950760ee186"
+  integrity sha512-412tsy+/z8nuRvYWiTs7Ft4qqD03VGnVMv5w6KRyurpc097IoWW+Z1/qZo6EudEIy3WYObIzGZDVSMnPX7EV3w==
   dependencies:
-    "@aztec/foundation" "0.74.0"
-    "@aztec/l1-artifacts" "0.74.0"
+    "@aztec/blob-lib" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/l1-artifacts" "0.76.0"
     "@viem/anvil" "^0.0.10"
     dotenv "^16.0.3"
     tslib "^2.4.0"
     viem "2.22.8"
     zod "^3.23.8"
 
-"@aztec/foundation@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.74.0.tgz#5fcfe0af768a33aff18b95e73beaeb0c7f967f85"
-  integrity sha512-L7N2WxOAJFh2pgMRLVNHuqeKBShxmAr1/7zzqcA4i4do038b1EQKWXdssPknI63XO+oXUV14Lr3z3n7kOxRt3Q==
+"@aztec/foundation@0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2":
+  version "0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2.tgz#1169873f160c9a4ed46792ae567b27fe3b7cb630"
+  integrity sha512-/zx5bTEO3fN6lzcAW3Aw2gIomo3P4JZOhEgFnkMTQJ1XtzRGqKT58bB4gbeQfYUh9PATq7VStKHav7VlWGGU7w==
   dependencies:
-    "@aztec/bb.js" "0.74.0"
+    "@aztec/bb.js" "0.75.0-commit.c03ba01a2a4122e43e90d5133ba017e54b90e9d2"
     "@koa/cors" "^5.0.0"
     "@noble/curves" "^1.2.0"
     bn.js "^5.2.1"
@@ -141,40 +152,70 @@
     sha3 "^2.1.4"
     zod "^3.23.8"
 
-"@aztec/l1-artifacts@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.74.0.tgz#5178e8818283e02fae98108f31e4ad458d8f7cea"
-  integrity sha512-BSPoJij5fyIDXI9MRPRGm0QIKnYVP4FhpyVFB0v/zfgCz8rwG2hvwz7DEnTATUEqNWKX/f5nDlri5pHe9mizzA==
+"@aztec/foundation@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/foundation/-/foundation-0.76.0.tgz#d6545d3a96786c0958109b2cebbca50f9785c34e"
+  integrity sha512-Y8S7l0FrOxTW8Kj7Lq2AbZHsvpwVt45DWisbp63rlyKUGwOZcouW8zI5m/wUGUPDDvXo/tDCTA9aUB15GW+DNQ==
+  dependencies:
+    "@aztec/bb.js" "0.76.0"
+    "@koa/cors" "^5.0.0"
+    "@noble/curves" "^1.2.0"
+    bn.js "^5.2.1"
+    c-kzg "4.0.0-alpha.1"
+    colorette "^2.0.20"
+    debug "^4.3.4"
+    detect-node "^2.1.0"
+    elliptic "^6.5.4"
+    hash.js "^1.1.7"
+    koa "^2.14.2"
+    koa-bodyparser "^4.4.0"
+    koa-compress "^5.1.0"
+    koa-router "^12.0.0"
+    leveldown "^6.1.1"
+    levelup "^5.1.1"
+    lodash.chunk "^4.2.0"
+    lodash.clonedeepwith "^4.5.0"
+    memdown "^6.1.1"
+    pako "^2.1.0"
+    pino "^9.5.0"
+    pino-pretty "^13.0.0"
+    sha3 "^2.1.4"
+    zod "^3.23.8"
+
+"@aztec/l1-artifacts@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/l1-artifacts/-/l1-artifacts-0.76.0.tgz#7e41fdd0919608cc8c12dce961cf5e497caf97c9"
+  integrity sha512-LEr5e8d42gNbW0hYsbzcT9qxQIiKZQWfHn3fwRCM+HYbiAS7OgtlRmFpv+xLRClruJP9CgYsbiweFjQ2xxmWIA==
   dependencies:
     tslib "^2.4.0"
 
-"@aztec/noir-contracts.js@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.74.0.tgz#d5ef6de823ec150433771588d92ad25a3e704a0a"
-  integrity sha512-USbjqKi2HJIdeI1bS2g0N5xhmv9OLNT2N7VxwIfeSUq32SxepjKDJ48uWizDHlUZvtJ5ZWy6PyqJuCrfmKYTNg==
+"@aztec/noir-contracts.js@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/noir-contracts.js/-/noir-contracts.js-0.76.0.tgz#0d5a32bf87b61aff89f0625b308a0adf1628029e"
+  integrity sha512-IyXWmpHInbZYMVYQj0Qy43gx4InJi+byENWYVi0IPd33GdyWqdQmoafoRoUPDaxbimLsoh5MtvvkuCL3a/T+WQ==
   dependencies:
-    "@aztec/aztec.js" "0.74.0"
+    "@aztec/aztec.js" "0.76.0"
     tslib "^2.4.0"
 
-"@aztec/protocol-contracts@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.74.0.tgz#0f88c394b6bae8f666f93bf02420578b7b77368f"
-  integrity sha512-grJs2fxzlZacYBEcRwiXvquWYCeQdz36JKpJnn8Cc65hD2LkGQ2DzvhzdZ+RXbup6/cdDUnn+vsJVGCJrvhE+Q==
+"@aztec/protocol-contracts@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/protocol-contracts/-/protocol-contracts-0.76.0.tgz#3cdc51362d9d9ee7810c7dd42b3007a27b6c361b"
+  integrity sha512-3yt1O9jQnLXFobPO85Iau4EXWm7f3PUqVvYAH8bRWlVm9dBe4SCNIMsEV7sX/llVRo+0xF2FgW61o4Xc2w7Bfg==
   dependencies:
-    "@aztec/circuits.js" "0.74.0"
-    "@aztec/foundation" "0.74.0"
-    "@aztec/types" "0.74.0"
+    "@aztec/circuits.js" "0.76.0"
+    "@aztec/foundation" "0.76.0"
+    "@aztec/types" "0.76.0"
     lodash.chunk "^4.2.0"
     lodash.omit "^4.5.0"
     tslib "^2.4.0"
 
-"@aztec/types@0.74.0":
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.74.0.tgz#875a309536f14c43c52822b5969e95b695d53f18"
-  integrity sha512-2YKIBFehlobJwQTX4WXr5E4NLktSozaHN2II4j5zCF2/5nSBCMHTBtXd8m+zQPl9UnXt1zH+2I2KuAHiLzNDSw==
+"@aztec/types@0.76.0":
+  version "0.76.0"
+  resolved "https://registry.yarnpkg.com/@aztec/types/-/types-0.76.0.tgz#f22567d4f649c3924212082de48a02156283c041"
+  integrity sha512-AGTbfsBQceciVkTErTPC/P+Z4rCJnjUlKxDEFa5Qr9osuamqwWTJOlOKIj2axu9Sw2F6Ll2zfGAyXAM3VMtr5g==
   dependencies:
-    "@aztec/ethereum" "0.74.0"
-    "@aztec/foundation" "0.74.0"
+    "@aztec/ethereum" "0.76.0"
+    "@aztec/foundation" "0.76.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.24.7":
   version "7.24.7"


### PR DESCRIPTION
All tests pass.
No issue, but in the flow of yarn install, needed to select @aztec/blob-lib v0.75.0 (and accept @aztec/bb.js 0.76.0).