### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/testnet_scripts.yaml
+++ b/.github/workflows/testnet_scripts.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Reference: https://github.com/actions/checkout/releases/tag/v4.2.2






