### PR TITLE
Update Docker Buildx Action to v3

### DIFF
--- a/.github/workflows/testnet_scripts.yaml
+++ b/.github/workflows/testnet_scripts.yaml
@@ -23,7 +23,7 @@ jobs:
           cache: 'yarn' # Optional: cache dependencies for faster builds
 
       - name: Set up Docker
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Install Aztec CLI
         run: |


### PR DESCRIPTION
- uses: docker/setup-buildx-action@v2
+ uses: docker/setup-buildx-action@v3

Reference
https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1