### PR TITLE
fix: correct assert error message in test_initializer test

### DIFF
--- a/src/test/first.nr
+++ b/src/test/first.nr
@@ -11,7 +11,7 @@ unconstrained fn test_initializer() {
     let block_number = get_block_number();
     let admin_slot = EasyPrivateVoting::storage_layout().admin.slot;
     let admin_storage_value = storage_read(voting_contract_address, admin_slot, block_number);
-    assert(admin_storage_value == admin, "Vote ended should be false");
+    assert(admin_storage_value == admin, "Admin should be correctly stored");
 }
 
 #[test]


### PR DESCRIPTION
The assert message in test_initializer was incorrectly referring to 'Vote ended should be false' 
when the test actually validates that the admin value is correctly stored in contract storage. 
This was misleading as the test has nothing to do with vote_ended status but specifically 
tests the admin initialization. Changed the message to 'Admin should be correctly stored' 
to accurately reflect what the assertion is checking.