### PR TITLE
chore: add missing semicolons in setup_pxe.ts

### DIFF
--- a/src/utils/setup_pxe.ts
+++ b/src/utils/setup_pxe.ts
@@ -1,13 +1,13 @@
 
 import { createPXEService, getPXEServiceConfig } from '@aztec/pxe/server';
-import { createStore } from "@aztec/kv-store/lmdb"
+import { createStore } from "@aztec/kv-store/lmdb";
 import { createAztecNodeClient, waitForPXE } from '@aztec/aztec.js';
 
 const { NODE_URL = 'http://localhost:8080' } = process.env;
-const node = createAztecNodeClient(NODE_URL)
+const node = createAztecNodeClient(NODE_URL);
 const l1Contracts = await node.getL1ContractAddresses();
-const config = getPXEServiceConfig()
-const fullConfig = { ...config, l1Contracts }
+const config = getPXEServiceConfig();
+const fullConfig = { ...config, l1Contracts };
 fullConfig.proverEnabled = false;
 
 const store = await createStore('pxe', {


### PR DESCRIPTION
Updated src/utils/setup_pxe.ts to consistently end statements with semicolons; no logic changes.