### PR TITLE
docs: update copyright year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Spilsbury Holdings Ltd
+   Copyright 2026 Spilsbury Holdings Ltd
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates the copyright year from 2025 to 2026.

Keeping license files current for the new year.