### PR TITLE
Document read-logs script and utility function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,8 @@ yarn deploy::devnet       # Deploy contract to devnet
 yarn deploy-account       # Deploy a Schnorr account
 yarn multiple-wallet      # Deploy from one wallet, interact from another
 yarn profile              # Profile a transaction deployment
+yarn read-logs            # Demo utility function for client-side debug logging
+yarn read-logs::devnet    # Same on devnet
 ```
 
 ## Environment Configuration

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ You can find a handful of scripts in the `./scripts` folder.
 - `./scripts/profile_deploy.ts` shows how to profile a transaction and print the results.
 - `./scripts/interaction_existing_contract.ts` demonstrates how to interact with an already deployed pod racing contract, including creating games.
 - `./scripts/get_block.ts` is an example of how to retrieve and display block information from the Aztec node.
+- `./scripts/read_debug_logs.ts` demonstrates the `#[external("utility")]` pattern for client-side state inspection — runs a full game lifecycle, then calls the `debug_game_state` utility function to read public state and log it via `debug_log_format` without an on-chain transaction. Run with `yarn read-logs` (`LOG_LEVEL` is pre-configured by the yarn script).
 
 ### Utility Functions
 


### PR DESCRIPTION
## Summary
- Add `read_debug_logs.ts` to the README scripts list, describing the `#[external("utility")]` pattern for client-side state inspection
- Add `yarn read-logs` / `yarn read-logs::devnet` to CLAUDE.md's Deployment & Scripts section

Follows up on #246 which added the script and utility function but didn't update documentation.

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)